### PR TITLE
[1.0.3] Add further tests for get_norm_correction and change the structure of factors.json

### DIFF
--- a/.github/workflows/prepare_environment.sh
+++ b/.github/workflows/prepare_environment.sh
@@ -5,7 +5,7 @@ PYTHON_VERSION=$1
 
 conda create --quiet -c conda-forge -c free -n test-env \
     python="$PYTHON_VERSION" \
-    "pytest>=4.6" pylint pytest-cov pycodestyle \
-    setuptools setuptools_scm wheel
+    "pytest>=4.6" pylint pytest-cov pytest-mock pycodestyle \
+    mock setuptools setuptools_scm wheel
 source "${CONDA}/bin/activate" test-env
 pip install ".[testing]"

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,9 @@ channels:
   - defaults
 
 dependencies:
-  - pytest
-  - pylint
   - future
+  - mock
   - pre-commit
+  - pylint
+  - pytest
+  - pytest-mock

--- a/src/db12/factors.json
+++ b/src/db12/factors.json
@@ -1,8 +1,10 @@
 {
 	"python_version": {
-		"3.9.6": {
-			"Intel": 0.86,
-			"AMD": 0.71
+		"3.9": {
+			"cpu_brand": {
+				"Intel": 0.86,
+				"AMD": 0.71
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR:
- adds some tests for `get_norm_correction`
- change the structure of `factors.json` (`python_version` now only includes the major and the minor versions to avoid changing the file for each micro update of Python)