### PR TITLE
[1.0.4] fix: norm correction regex

### DIFF
--- a/src/db12/benchmark.py
+++ b/src/db12/benchmark.py
@@ -228,7 +228,7 @@ def get_norm_correction(norm_computed):
     try:
         with open("/proc/cpuinfo", "r") as file_object:
             content = file_object.read()
-        cpu_brand_name = re.findall("model name\t: ([a-zA-Z]*) ", content)[0]
+        cpu_brand_name = re.findall("model name\t: ([a-zA-Z]*)", content)[0]
     except (IOError, IndexError):
         logging.warning(
             "Cannot correct the score, return the raw norm: cannot access CPU information"


### PR DESCRIPTION
Very minor fix of the regex to better get the CPU model name from `/proc/cpuinfo`.